### PR TITLE
Support hidden code lines that still execute

### DIFF
--- a/examples/hidden_code_lines.md
+++ b/examples/hidden_code_lines.md
@@ -2,48 +2,6 @@
 title: Hidden Code Lines
 ---
 
-You can use the delimiter `"/// "` for lines of shell code
-that will not be visible in the code snippet in the presentation,
-but will still be executed.
-
-Here is an example for compiling and running a `java` program:
-
-```java +exec
-/// cat > HelloWorld.java << EOF
-public class HelloWorld {
-    public static void main(String[] args) {
-        System.out.println("Hello from Java!");
-    }
-}
-/// EOF
-/// javac HelloWorld.java
-/// java HelloWorld
-/// rm HelloWorld.java
-/// rm HelloWorld.class
-```
-
-<!-- end_slide -->
-
-You could even omit the enclosing class and method completely:
-
-```java +exec
-/// cat > HelloWorld.java << EOF
-/// public class HelloWorld {
-/// public static void main(String[] args) {
-System.out.println("Hello from Java!");
-/// }
-/// }
-/// EOF
-/// javac HelloWorld.java
-/// java HelloWorld
-/// rm HelloWorld.java
-/// rm HelloWorld.class
-```
-
-<!-- end_slide -->
-
-An example for `Rust`:
-
 ```rust +exec
 /// cat > hello.rs << EOF
 fn main() {
@@ -58,10 +16,63 @@ fn main() {
 
 <!-- end_slide -->
 
-An example for `python`:
+```rust +line_numbers
+let foo = 2;
+let bar = 2;
+let sum = foo + bar;
+println!("The sum is: {}", sum);
+```
 
-```python +exec
-/// python -c """
-print('Hello from Python!')
-/// """
+```rust +line_numbers
+/// fn main() {
+let foo = 2;
+let bar = 2;
+let sum = foo + bar;
+println!("The sum is: {}", sum);
+/// }
+```
+
+<!-- end_slide -->
+
+```rust {1,3,4,7,9-11} +line_numbers
+   fn potato() -> u32 {
+
+    println!("Hello world");
+    let mut q = 42;
+    q = q * 1337;
+    q = q * 1337;
+    q = q * 1337;
+    q = q * 1337;
+    q = q * 1337;
+    q = q * 1337;
+    q = q * 1337;
+    q = q * 1337;
+   }
+```
+
+```rust {1,3,4,7,9-11} +line_numbers
+///    fn potato() -> u32 {
+println!("Hello world");
+let mut q = 42;
+q = q * 1337;
+q = q * 1337;
+q = q * 1337;
+q = q * 1337;
+q = q * 1337;
+q = q * 1337;
+q = q * 1337;
+q = q * 1337;
+q = q * 1337;
+///    }
+```
+
+<!-- end_slide -->
+
+```rust {1|2|3|4}
+///   fn potato() -> u32 {
+println!("Hello world");
+let mut q = 42;
+q = q * 1337;
+500
+///   }
 ```

--- a/examples/hidden_code_lines.md
+++ b/examples/hidden_code_lines.md
@@ -8,7 +8,7 @@ but will still be executed.
 
 Here is an example for compiling and running a `java` program:
 
-```bash +exec
+```java +exec
 /// cat > HelloWorld.java << EOF
 public class HelloWorld {
     public static void main(String[] args) {
@@ -26,7 +26,7 @@ public class HelloWorld {
 
 You could even omit the enclosing class and method completely:
 
-```bash +exec
+```java +exec
 /// cat > HelloWorld.java << EOF
 /// public class HelloWorld {
 /// public static void main(String[] args) {
@@ -44,7 +44,7 @@ System.out.println("Hello from Java!");
 
 An example for `Rust`:
 
-```bash +exec
+```rust +exec
 /// cat > hello.rs << EOF
 fn main() {
     println!("Hello from Rust!");
@@ -60,7 +60,7 @@ fn main() {
 
 An example for `python`:
 
-```bash +exec
+```python +exec
 /// python -c """
 print('Hello from Python!')
 /// """

--- a/examples/hidden_code_lines.md
+++ b/examples/hidden_code_lines.md
@@ -2,6 +2,8 @@
 title: Hidden Code Lines
 ---
 
+Compile and execute Rust code using hidden code lines:
+
 ```rust +exec
 /// cat > hello.rs << EOF
 fn main() {
@@ -16,12 +18,18 @@ fn main() {
 
 <!-- end_slide -->
 
+# Line Numbering
+
+This is how the line numbers render without any hidden code lines:
+
 ```rust +line_numbers
 let foo = 2;
 let bar = 2;
 let sum = foo + bar;
 println!("The sum is: {}", sum);
 ```
+
+Observe that the line numbering in the following snippet matches the above. The following snippet has a hidden enclosed main function:
 
 ```rust +line_numbers
 /// fn main() {
@@ -34,24 +42,12 @@ println!("The sum is: {}", sum);
 
 <!-- end_slide -->
 
-```rust {1,3,4,7,9-11} +line_numbers
-   fn potato() -> u32 {
+# Selective Highlighting
 
-    println!("Hello world");
-    let mut q = 42;
-    q = q * 1337;
-    q = q * 1337;
-    q = q * 1337;
-    q = q * 1337;
-    q = q * 1337;
-    q = q * 1337;
-    q = q * 1337;
-    q = q * 1337;
-   }
-```
+The following code snippet has a hidden enclosing main function. The lines `{1,3,4,7,9-11}` should be highlighted, which match the visible code line numbers:
 
 ```rust {1,3,4,7,9-11} +line_numbers
-///    fn potato() -> u32 {
+/// fn main() {
 println!("Hello world");
 let mut q = 42;
 q = q * 1337;
@@ -63,16 +59,21 @@ q = q * 1337;
 q = q * 1337;
 q = q * 1337;
 q = q * 1337;
-///    }
+/// }
 ```
 
 <!-- end_slide -->
 
+# Dynamic Highlighting
+
+Dynamic highlighting also respects the hidden/visible code lines. Here we highlight each line on each consectuive slide, in turn:
+
 ```rust {1|2|3|4}
-///   fn potato() -> u32 {
+/// fn main() {
 println!("Hello world");
 let mut q = 42;
 q = q * 1337;
-500
-///   }
+/// hidden
+500;
+/// }
 ```

--- a/examples/hidden_code_lines.md
+++ b/examples/hidden_code_lines.md
@@ -1,0 +1,67 @@
+---
+title: Hidden Code Lines
+---
+
+You can use the delimiter `"/// "` for lines of shell code
+that will not be visible in the code snippet in the presentation,
+but will still be executed.
+
+Here is an example for compiling and running a `java` program:
+
+```bash +exec
+/// cat > HelloWorld.java << EOF
+public class HelloWorld {
+    public static void main(String[] args) {
+        System.out.println("Hello from Java!");
+    }
+}
+/// EOF
+/// javac HelloWorld.java
+/// java HelloWorld
+/// rm HelloWorld.java
+/// rm HelloWorld.class
+```
+
+<!-- end_slide -->
+
+You could even omit the enclosing class and method completely:
+
+```bash +exec
+/// cat > HelloWorld.java << EOF
+/// public class HelloWorld {
+/// public static void main(String[] args) {
+System.out.println("Hello from Java!");
+/// }
+/// }
+/// EOF
+/// javac HelloWorld.java
+/// java HelloWorld
+/// rm HelloWorld.java
+/// rm HelloWorld.class
+```
+
+<!-- end_slide -->
+
+An example for `Rust`:
+
+```bash +exec
+/// cat > hello.rs << EOF
+fn main() {
+    println!("Hello from Rust!");
+}
+/// EOF
+/// rustc hello.rs
+/// ./hello
+/// rm hello.rs
+/// rm hello
+```
+
+<!-- end_slide -->
+
+An example for `python`:
+
+```bash +exec
+/// python -c """
+print('Hello from Python!')
+/// """
+```

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -1,6 +1,6 @@
 //! Code execution.
 
-use crate::{markdown::elements::Code, processing::builder::HIDDEN_CODE_LINE_DELIMITER};
+use crate::markdown::elements::Code;
 use std::{
     io::{self, BufRead, BufReader, Write},
     process::{self, Stdio},
@@ -19,11 +19,10 @@ impl CodeExecuter {
             return Err(CodeExecuteError::NotExecutableCode);
         }
         // TODO: Need to specify interpreter in the CodeAttributes instead of hardcoding.
-        Self::execute_shell("sh", &code.contents)
+        Self::execute_shell("sh", &code.executable_contents())
     }
 
     fn execute_shell(interpreter: &str, code: &str) -> Result<ExecutionHandle, CodeExecuteError> {
-        let code = code.replace(HIDDEN_CODE_LINE_DELIMITER, "");
         let mut output_file = NamedTempFile::new().map_err(CodeExecuteError::TempFile)?;
         output_file.write_all(code.as_bytes()).map_err(CodeExecuteError::TempFile)?;
         output_file.flush().map_err(CodeExecuteError::TempFile)?;

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -1,6 +1,9 @@
 //! Code execution.
 
-use crate::markdown::elements::{Code, CodeLanguage};
+use crate::{
+    markdown::elements::{Code, CodeLanguage},
+    processing::builder::HIDDEN_CODE_LINE_DELIMITER,
+};
 use std::{
     io::{self, BufRead, BufReader, Write},
     process::{self, Stdio},
@@ -28,6 +31,7 @@ impl CodeExecuter {
     }
 
     fn execute_shell(interpreter: &str, code: &str) -> Result<ExecutionHandle, CodeExecuteError> {
+        let code = code.replace(HIDDEN_CODE_LINE_DELIMITER, "");
         let mut output_file = NamedTempFile::new().map_err(CodeExecuteError::TempFile)?;
         output_file.write_all(code.as_bytes()).map_err(CodeExecuteError::TempFile)?;
         output_file.flush().map_err(CodeExecuteError::TempFile)?;

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -1,9 +1,6 @@
 //! Code execution.
 
-use crate::{
-    markdown::elements::{Code, CodeLanguage},
-    processing::builder::HIDDEN_CODE_LINE_DELIMITER,
-};
+use crate::{markdown::elements::Code, processing::builder::HIDDEN_CODE_LINE_DELIMITER};
 use std::{
     io::{self, BufRead, BufReader, Write},
     process::{self, Stdio},
@@ -18,16 +15,11 @@ pub(crate) struct CodeExecuter;
 impl CodeExecuter {
     /// Execute a piece of code.
     pub(crate) fn execute(code: &Code) -> Result<ExecutionHandle, CodeExecuteError> {
-        if !code.language.supports_execution() {
-            return Err(CodeExecuteError::UnsupportedExecution);
-        }
         if !code.attributes.execute {
             return Err(CodeExecuteError::NotExecutableCode);
         }
-        match &code.language {
-            CodeLanguage::Shell(interpreter) => Self::execute_shell(interpreter, &code.contents),
-            _ => Err(CodeExecuteError::UnsupportedExecution),
-        }
+        // TODO: Need to specify interpreter in the CodeAttributes instead of hardcoding.
+        Self::execute_shell("sh", &code.contents)
     }
 
     fn execute_shell(interpreter: &str, code: &str) -> Result<ExecutionHandle, CodeExecuteError> {
@@ -56,9 +48,6 @@ impl CodeExecuter {
 /// An error during the execution of some code.
 #[derive(thiserror::Error, Debug)]
 pub(crate) enum CodeExecuteError {
-    #[error("code language doesn't support execution")]
-    UnsupportedExecution,
-
     #[error("code is not marked for execution")]
     NotExecutableCode,
 
@@ -157,7 +146,7 @@ impl ProcessStatus {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::markdown::elements::CodeAttributes;
+    use crate::markdown::elements::{CodeAttributes, CodeLanguage};
 
     #[test]
     fn shell_code_execution() {

--- a/src/markdown/code.rs
+++ b/src/markdown/code.rs
@@ -16,9 +16,6 @@ impl CodeBlockParser {
     fn parse_block_info(input: &str) -> ParseResult<(CodeLanguage, CodeAttributes)> {
         let (language, input) = Self::parse_language(input);
         let attributes = Self::parse_attributes(input)?;
-        if attributes.execute && !language.supports_execution() {
-            return Err(CodeBlockParseError::UnsupportedAttribute(language, "execution"));
-        }
         if attributes.auto_render && !language.supports_auto_render() {
             return Err(CodeBlockParseError::UnsupportedAttribute(language, "rendering"));
         }

--- a/src/markdown/elements.rs
+++ b/src/markdown/elements.rs
@@ -244,10 +244,6 @@ pub(crate) enum CodeLanguage {
 }
 
 impl CodeLanguage {
-    pub(crate) fn supports_execution(&self) -> bool {
-        matches!(self, Self::Shell(_))
-    }
-
     pub(crate) fn supports_auto_render(&self) -> bool {
         matches!(self, Self::Latex | Self::Typst)
     }

--- a/src/markdown/elements.rs
+++ b/src/markdown/elements.rs
@@ -185,6 +185,18 @@ pub(crate) struct Code {
     pub(crate) attributes: CodeAttributes,
 }
 
+impl Code {
+    const HIDDEN_CODE_LINE_DELIMITER: &'static str = "/// ";
+
+    pub(crate) fn visible_lines(&self) -> impl Iterator<Item = &str> {
+        self.contents.lines().filter(|line| !line.starts_with(Self::HIDDEN_CODE_LINE_DELIMITER))
+    }
+
+    pub(crate) fn executable_contents(&self) -> String {
+        self.contents.replace(Self::HIDDEN_CODE_LINE_DELIMITER, "")
+    }
+}
+
 /// The language of a piece of code.
 #[derive(Clone, Debug, PartialEq, Eq, EnumIter)]
 pub(crate) enum CodeLanguage {

--- a/src/processing/builder.rs
+++ b/src/processing/builder.rs
@@ -37,7 +37,6 @@ use super::modals::KeyBindingsModalBuilder;
 // TODO: move to a theme config.
 static DEFAULT_BOTTOM_SLIDE_MARGIN: u16 = 3;
 static DEFAULT_Z_INDEX: i32 = -2;
-pub static HIDDEN_CODE_LINE_DELIMITER: &str = "/// ";
 
 #[derive(Default)]
 pub struct Themes {
@@ -718,7 +717,7 @@ impl<'a> PresentationBuilder<'a> {
 
         let mut output = Vec::new();
         let block_style = &self.theme.code;
-        for line in lines.into_iter().filter(|line| !line.code.starts_with(HIDDEN_CODE_LINE_DELIMITER)) {
+        for line in lines.into_iter() {
             let highlighted = line.highlight(&padding_style, &mut code_highlighter, block_style);
             let not_highlighted = line.highlight(&padding_style, &mut empty_highlighter, block_style);
             let width = line.width();

--- a/src/processing/builder.rs
+++ b/src/processing/builder.rs
@@ -37,6 +37,7 @@ use super::modals::KeyBindingsModalBuilder;
 // TODO: move to a theme config.
 static DEFAULT_BOTTOM_SLIDE_MARGIN: u16 = 3;
 static DEFAULT_Z_INDEX: i32 = -2;
+pub static HIDDEN_CODE_LINE_DELIMITER: &str = "/// ";
 
 #[derive(Default)]
 pub struct Themes {
@@ -717,7 +718,7 @@ impl<'a> PresentationBuilder<'a> {
 
         let mut output = Vec::new();
         let block_style = &self.theme.code;
-        for line in lines.into_iter() {
+        for line in lines.into_iter().filter(|line| !line.code.starts_with(HIDDEN_CODE_LINE_DELIMITER)) {
             let highlighted = line.highlight(&padding_style, &mut code_highlighter, block_style);
             let not_highlighted = line.highlight(&padding_style, &mut empty_highlighter, block_style);
             let width = line.width();

--- a/src/processing/code.rs
+++ b/src/processing/code.rs
@@ -42,8 +42,8 @@ impl<'a> CodePreparer<'a> {
         }
 
         let padding = " ".repeat(horizontal_padding as usize);
-        let padder = NumberPadder::new(code.contents.lines().count());
-        for (index, line) in code.contents.lines().enumerate() {
+        let padder = NumberPadder::new(code.visible_lines().count());
+        for (index, line) in code.visible_lines().enumerate() {
             let mut line = line.to_string();
             let mut prefix = padding.clone();
             if code.attributes.line_numbers {


### PR DESCRIPTION
This is a POC approach for supporting running code snippet in multiple languages, as raised in https://github.com/mfontanini/presenterm/issues/242.

This approach is inspired by `rustdoc`'s feature for pre-processing code in `rustdoc` code comments, but not displaying it in the resulting docs. It uses the delimiter `"/// "` to hide code from the snippet in the presentation, but still executes it.

See https://github.com/dmackdev/presenterm/blob/support-hidden-code-lines/examples/hidden_code_lines.md for the examples, and a demo below.

What would also benefit is to decouple the programming language specified for the snippet highlighting, from the language to execute the code (currently only bash). I have done this expediently for demonstration purposes by hardcoding the interpreter for the code execution, and removing the checks for an executable code language, but this could be implemented properly.

https://github.com/dmackdev/presenterm/assets/79006698/ea1bdf69-4ff4-4671-90bd-76d8e666de52