### PR TITLE
Show `stderr` output from code execution

### DIFF
--- a/examples/code.md
+++ b/examples/code.md
@@ -13,6 +13,7 @@ This presentation shows how to:
 
 * Left-align code blocks.
 * Have code blocks without background.
+* Execute code snippets.
 
 ```rust
 pub struct Greeter {
@@ -73,4 +74,33 @@ fn main() {
     let greeting = greeter.greet("Mark");
     println!("{greeting}");
 }
+```
+
+<!-- end_slide -->
+
+Code execution
+===
+
+Run commands from the presentation and display their output dynamically.
+
+```bash +exec
+for i in $(seq 1 5)
+do
+    echo "hi $i"
+    sleep 0.5
+done
+```
+
+<!-- end_slide -->
+
+Code execution - `stderr`
+===
+
+Output from `stderr` will also be shown as output.
+
+```bash +exec
+echo "This is a successful command"
+echo "This message redirects to stderr" >&2
+echo "This is a successful command again"
+man # Missing argument
 ```

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -102,13 +102,11 @@ impl ProcessReader {
         let stderr = self.handle.stderr.take().expect("no stderr");
         let stderr = BufReader::new(stderr);
         let _ = Self::process_output(self.state.clone(), stdout, stderr);
-        let success = match self.handle.try_wait() {
-            Ok(Some(code)) => code.success(),
-            _ => false,
-        };
+        let success = self.handle.try_wait().ok().flatten().map(|s| s.success());
         let status = match success {
-            true => ProcessStatus::Success,
-            false => ProcessStatus::Failure,
+            Some(true) => ProcessStatus::Success,
+            Some(false) => ProcessStatus::Failure,
+            None => ProcessStatus::Running,
         };
         self.state.lock().unwrap().status = status;
     }

--- a/src/processing/execution.rs
+++ b/src/processing/execution.rs
@@ -1,5 +1,5 @@
 use crate::{
-    execute::{CodeExecuter, ExecutionHandle, ExecutionState, ProcessStatus},
+    execute::{CodeExecuter, ExecutionHandle, ExecutionState},
     markdown::elements::Code,
     presentation::{AsRenderOperations, PreformattedLine, RenderOnDemand, RenderOnDemandState, RenderOperation},
     render::properties::WindowSize,
@@ -87,14 +87,15 @@ impl RenderOnDemand for RunCodeOperation {
         let mut inner = self.inner.borrow_mut();
         if let Some(handle) = inner.handle.as_mut() {
             let state = handle.state();
-            let ExecutionState { output, status } = state;
+            let ExecutionState { output, error_output, status } = state;
             if status.is_finished() {
                 inner.handle.take();
                 inner.state = RenderOnDemandState::Rendered;
             }
             inner.output_lines = output;
-            if matches!(status, ProcessStatus::Failure) {
-                inner.output_lines.push("[finished with error]".to_string());
+            if !error_output.is_empty() {
+                inner.output_lines.push("stderr:".to_string());
+                inner.output_lines.append(&mut error_output.clone())
             }
         }
         inner.state.clone()


### PR DESCRIPTION
An approach for https://github.com/mfontanini/presenterm/issues/247.

This simply pipes `stderr` output and shows it (if any output) after the code execution. It replaces the `[finished with error]` message seen before, and does not set the `ProcessStatus` to failure if it has not finished executing.

Note that the output is captured/shown separately to the `stdout` output and is not interleaved. But correct interleaving of `stdout`/`stderr` could be achieved - with the [os_pipe](https://crates.io/crates/os_pipe) crate, or otherwise. See this implemented [here](https://github.com/dmackdev/presenterm/pull/3).

https://github.com/dmackdev/presenterm/assets/79006698/dfd01da1-b79a-408a-ad07-5c31039da623