### PR TITLE
Show `stderr` output from code execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,6 +797,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "os_pipe"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57119c3b893986491ec9aa85056780d3a0f3cf4da7cc09dd3650dbd6c6738fb9"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,6 +891,7 @@ dependencies = [
  "itertools",
  "merge-struct",
  "once_cell",
+ "os_pipe",
  "rand",
  "rstest",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ tempfile = "3.10"
 console = "0.15.8"
 thiserror = "1"
 unicode-width = "0.1"
+os_pipe = "1.1.5"
 
 [dependencies.syntect]
 version = "5.2"

--- a/examples/code.md
+++ b/examples/code.md
@@ -100,7 +100,10 @@ Output from `stderr` will also be shown as output.
 
 ```bash +exec
 echo "This is a successful command"
+sleep 0.5
 echo "This message redirects to stderr" >&2
+sleep 0.5
 echo "This is a successful command again"
+sleep 0.5
 man # Missing argument
 ```

--- a/examples/code.md
+++ b/examples/code.md
@@ -13,6 +13,7 @@ This presentation shows how to:
 
 * Left-align code blocks.
 * Have code blocks without background.
+* Execute code snippets.
 
 ```rust
 pub struct Greeter {
@@ -73,4 +74,33 @@ fn main() {
     let greeting = greeter.greet("Mark");
     println!("{greeting}");
 }
+```
+
+<!-- end_slide -->
+
+Code execution
+===
+
+Run commands from the presentation and display their output dynamically.
+
+```bash +exec
+for i in $(seq 1 5)
+do
+    echo "hi $i"
+    sleep 0.5
+done
+```
+
+<!-- end_slide -->
+
+Code execution - `stderr`
+===
+
+Output from `stderr` will also be shown as output.
+
+```bash +exec
+echo "This is a successful command"
+echo "This message redirects to stderr" >&2
+echo "This is a successful command again"
+man # Missing argument
 ```

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -2,10 +2,10 @@
 
 use crate::markdown::elements::{Code, CodeLanguage};
 use std::{
-    io::{self, BufRead, BufReader, Write},
-    process::{self, ChildStdout, Stdio},
+    io::{self, Read, Write},
+    process::{self, Stdio},
     sync::{Arc, Mutex},
-    thread::{self},
+    thread,
 };
 use tempfile::NamedTempFile;
 
@@ -31,17 +31,19 @@ impl CodeExecuter {
         let mut output_file = NamedTempFile::new().map_err(CodeExecuteError::TempFile)?;
         output_file.write_all(code.as_bytes()).map_err(CodeExecuteError::TempFile)?;
         output_file.flush().map_err(CodeExecuteError::TempFile)?;
+        let (reader, writer) = os_pipe::pipe().map_err(CodeExecuteError::Pipe)?;
+        let writer_clone = writer.try_clone().map_err(CodeExecuteError::Pipe)?;
         let process_handle = process::Command::new("/usr/bin/env")
             .arg(interpreter)
             .arg(output_file.path())
             .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::null())
+            .stdout(writer)
+            .stderr(writer_clone)
             .spawn()
             .map_err(CodeExecuteError::SpawnProcess)?;
 
         let state: Arc<Mutex<ExecutionState>> = Default::default();
-        let reader_handle = ProcessReader::spawn(process_handle, state.clone(), output_file);
+        let reader_handle = ProcessReader::spawn(process_handle, state.clone(), output_file, reader);
         let handle = ExecutionHandle { state, reader_handle };
         Ok(handle)
     }
@@ -61,6 +63,9 @@ pub(crate) enum CodeExecuteError {
 
     #[error("error spawning process: {0}")]
     SpawnProcess(io::Error),
+
+    #[error("error creating pipe: {0}")]
+    Pipe(io::Error),
 }
 
 /// A handle for the execution of a piece of code.
@@ -84,6 +89,7 @@ struct ProcessReader {
     state: Arc<Mutex<ExecutionState>>,
     #[allow(dead_code)]
     file_handle: NamedTempFile,
+    reader: os_pipe::PipeReader,
 }
 
 impl ProcessReader {
@@ -91,15 +97,14 @@ impl ProcessReader {
         handle: process::Child,
         state: Arc<Mutex<ExecutionState>>,
         file_handle: NamedTempFile,
+        reader: os_pipe::PipeReader,
     ) -> thread::JoinHandle<()> {
-        let reader = Self { handle, state, file_handle };
+        let reader = Self { handle, state, file_handle, reader };
         thread::spawn(|| reader.run())
     }
 
     fn run(mut self) {
-        let stdout = self.handle.stdout.take().expect("no stdout");
-        let stdout = BufReader::new(stdout);
-        let _ = Self::process_output(self.state.clone(), stdout);
+        let _ = Self::process_output(self.state.clone(), self.reader);
         let success = match self.handle.try_wait() {
             Ok(Some(code)) => code.success(),
             _ => false,
@@ -111,12 +116,11 @@ impl ProcessReader {
         self.state.lock().unwrap().status = status;
     }
 
-    fn process_output(state: Arc<Mutex<ExecutionState>>, stdout: BufReader<ChildStdout>) -> io::Result<()> {
-        for line in stdout.lines() {
-            let line = line?;
-            // TODO: consider not locking per line...
-            state.lock().unwrap().output.push(line);
-        }
+    fn process_output(state: Arc<Mutex<ExecutionState>>, mut reader: os_pipe::PipeReader) -> io::Result<()> {
+        let mut output = String::new();
+        reader.read_to_string(&mut output)?;
+        let mut lines: Vec<_> = output.lines().map(String::from).collect();
+        state.lock().unwrap().output.append(&mut lines);
         Ok(())
     }
 }
@@ -182,5 +186,30 @@ echo 'bye'"
         };
         let result = CodeExecuter::execute(&code);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn shell_code_execution_captures_stderr() {
+        let contents = r"
+echo 'This message redirects to stderr' >&2
+echo 'hello world'
+man
+"
+        .into();
+        let code = Code {
+            contents,
+            language: CodeLanguage::Shell("sh".into()),
+            attributes: CodeAttributes { execute: true, ..Default::default() },
+        };
+        let handle = CodeExecuter::execute(&code).expect("execution failed");
+        let state = loop {
+            let state = handle.state();
+            if state.status.is_finished() {
+                break state;
+            }
+        };
+
+        let expected_lines = vec!["This message redirects to stderr", "hello world", "What manual page do you want?"];
+        assert_eq!(state.output, expected_lines);
     }
 }


### PR DESCRIPTION
This uses the [os_pipe](https://crates.io/crates/os_pipe) crate to capture both `stdout` and `stderr` from code execution, displaying them interleaved as you would see it in the terminal. The interactivity of seeing each output line as it happens (instead of all at the end) is retained.

https://github.com/dmackdev/presenterm/assets/79006698/0b93e4b3-96dd-4e98-9ac0-e03dd1b43514